### PR TITLE
Adds the ability to set a maximum height of the legend

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -36,6 +36,7 @@ var DBLCLICKDELAY = interactConstants.DBLCLICKDELAY;
 
 module.exports = function draw(gd) {
     var fullLayout = gd._fullLayout;
+    var legendLayout = gd.layout.legend || {};
     var clipId = 'legend' + fullLayout._uid;
 
     if(!fullLayout._infolayer || !gd.calcdata) return;
@@ -185,8 +186,8 @@ module.exports = function draw(gd) {
             // Make sure the legend top and bottom are visible
             // (legends with a scroll bar are not allowed to stretch beyond the extended
             // margins)
-            var legendHeight = opts._height,
-                legendHeightMax = gs.h;
+            var legendHeight = (legendLayout.maxHeight) ? Math.min(opts._height, legendLayout.maxHeight) : opts._height;
+            var legendHeightMax = gs.h;
 
             if(legendHeight > legendHeightMax) {
                 ly = gs.t;


### PR DESCRIPTION
This PR adds the ability to set a maximum height for the legend.  As far as I know, there is no way to currently do this, so (in combination with the negative anchor bug), causes large legends to completely block the graph.  Without this, it's almost impossible to make sure the legend has enough extra room to fit.

Please help me add this functionality

Before opening a pull request, developer should: 

- `git rebase` their local branch off the latest `master`,
- make sure to **not** `git add` the `dist/` folder (the `dist/` is updated only on version bumps),
- make sure to commit changes to the `package-lock.json` file (if any),
- write an overview of what the PR attempts to do,
- select the _Allow edits from maintainers_ option (see this [article](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for more details).

Note that it is forbidden to force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please `git merge master` into your PR branch instead of `git rebase master`.
